### PR TITLE
bugfix(ui): resolve convert and extract progress dialog doesn't start/complete correctly

### DIFF
--- a/lib/views/convert/convert_page.dart
+++ b/lib/views/convert/convert_page.dart
@@ -430,10 +430,12 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
         .forEach(
           (line) {
             if (line.contains('out_time_ms')) {
-              final currentDuration = double.parse(line.split('\n')[6].split('=').removeLast());
-              progressSetstate(() {
-                convertProgress = (currentDuration / 1000000 / totalDuration) * 100;
-              });
+              try {
+                final currentDuration = double.parse(line.split('\n')[6].split('=').removeLast());
+                progressSetstate(() {
+                  convertProgress = (currentDuration / 1000000 / totalDuration) * 100;
+                });
+              } catch (_) {}
             }
           });
 

--- a/lib/views/extract/extract_page.dart
+++ b/lib/views/extract/extract_page.dart
@@ -405,11 +405,13 @@ class _ExtractPageState extends State<ExtractPage> with WindowListener {
       // get extract progress
       await res.stdout.transform(utf8.decoder).forEach((line) {
         if (line.contains('out_time_ms')) {
-          final currentDuration =
+          try {
+            final currentDuration =
               double.parse(line.split('\n')[6].split('=').removeLast());
-          progressSetstate(() {
-            convertProgress = (currentDuration / 1000000 / totalDuration) * 100;
-          });
+            progressSetstate(() {
+              convertProgress = (currentDuration / 1000000 / totalDuration) * 100;
+            });
+          } catch(_) {}
         }
       });
 


### PR DESCRIPTION
## Background
When converting/extracting some video files, the popup dialog which has the progress bar doesn't move corresponding to the actual processing progress. However, the process of converting/extracting still runs and completes in the background.

## Problem
The converting/extracting process needs to be parsed as 'double' data type. However, when the process starts, it returns a value that isn't able to parsed as a 'double' which returns an error.

## Fix
Wrap the parsing inside a try-catch block to prevent the progress bar on breaking on start. 