### PR TITLE
chore/refactor and rename ffmpeg ffprobe class

### DIFF
--- a/lib/services/ffmpeg_service.dart
+++ b/lib/services/ffmpeg_service.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-class Ffmpeg {
-  Future<bool> isInstalled() async {
+class FfmpegService {
+  static Future<bool> isInstalled() async {
     final res = await Process.run('ffmpeg', ['-version']);
     if (res.exitCode == 0 && res.stdout.toString().contains('ffmpeg')) {
       return true;

--- a/lib/services/ffprobe_service.dart
+++ b/lib/services/ffprobe_service.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-class Ffprobe {
-  Future<bool> isInstalled() async {
+class FfprobeService {
+  static Future<bool> isInstalled() async {
     final res = await Process.run('ffprobe', ['-version']);
     if (res.exitCode == 0 && res.stdout.toString().contains('ffprobe')) {
       return true;
@@ -24,7 +24,7 @@ class Ffprobe {
   Future<double> getTotalDuration({
     required String filePath
   }) async {
-    final ffprobe = Ffprobe();
+    final ffprobe = FfprobeService();
     final res = await ffprobe.run(
       filePath: filePath,
       printFormat: 'compact',

--- a/lib/views/analyze/analyze_page.dart
+++ b/lib/views/analyze/analyze_page.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:mediashin/models/collections/colors.dart';
-import 'package:mediashin/services/ffprobe.dart';
+import 'package:mediashin/services/ffprobe_service.dart';
 import 'package:mediashin/utils/select_video_file.dart';
 import 'package:mediashin/models/video_details.dart';
 import 'package:mime/mime.dart';
@@ -226,7 +226,7 @@ class _AnalyzePageState extends State<AnalyzePage> with WindowListener {
         }
       );
 
-      final ffprobe = Ffprobe();
+      final ffprobe = FfprobeService();
       var videoDetailsStr = await ffprobe.run(
         printFormat: 'json',
         filePath: filePath,

--- a/lib/views/convert/convert_page.dart
+++ b/lib/views/convert/convert_page.dart
@@ -4,8 +4,8 @@ import 'package:desktop_drop/desktop_drop.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:mediashin/models/collections/colors.dart';
-import 'package:mediashin/services/ffmpeg.dart';
-import 'package:mediashin/services/ffprobe.dart';
+import 'package:mediashin/services/ffmpeg_service.dart';
+import 'package:mediashin/services/ffprobe_service.dart';
 import 'package:mediashin/utils/select_video_file.dart';
 import 'package:mediashin/models/collections/statics.dart';
 import 'package:mediashin/widgets/window_title_bar.dart';
@@ -408,11 +408,11 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
       );
 
       // get total duration of video stream
-      final ffprobe = Ffprobe();
+      final ffprobe = FfprobeService();
       final totalDuration = await ffprobe.getTotalDuration(filePath: filePath);
 
       // run convert
-      final ffmpeg = Ffmpeg();
+      final ffmpeg = FfmpegService();
       final res = await ffmpeg.convert(
         filePath: filePath,
         outputFileNameWithPath: outputFileNameFinal,

--- a/lib/views/extract/extract_page.dart
+++ b/lib/views/extract/extract_page.dart
@@ -3,8 +3,8 @@ import 'dart:convert';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:mediashin/models/collections/colors.dart';
-import 'package:mediashin/services/ffmpeg.dart';
-import 'package:mediashin/services/ffprobe.dart';
+import 'package:mediashin/services/ffmpeg_service.dart';
+import 'package:mediashin/services/ffprobe_service.dart';
 import 'package:mediashin/utils/select_video_file.dart';
 import 'package:mediashin/models/collections/statics.dart';
 import 'package:mediashin/widgets/window_title_bar.dart';
@@ -316,7 +316,7 @@ class _ExtractPageState extends State<ExtractPage> with WindowListener {
   Future<List<String>> _getAudioCodecsFromVideoFile(String filePath) async {
     if (lookupMimeType(filePath)!.startsWith('video/')) {
       // get audio codec
-      final ffprobe = Ffprobe();
+      final ffprobe = FfprobeService();
       var videoDetailsStr = await ffprobe.run(
           printFormat: 'json',
           filePath: filePath,
@@ -392,11 +392,11 @@ class _ExtractPageState extends State<ExtractPage> with WindowListener {
           });
 
       // get total duration of video stream
-      final ffprobe = Ffprobe();
+      final ffprobe = FfprobeService();
       final totalDuration = await ffprobe.getTotalDuration(filePath: filePath);
 
       // extract audio based on the found codec
-      final ffmpeg = Ffmpeg();
+      final ffmpeg = FfmpegService();
       final res = await ffmpeg.extractAudio(
         filePath: filePath,
         outputFileNameWithPath: outputFileNameFinal,

--- a/lib/views/home/home_page.dart
+++ b/lib/views/home/home_page.dart
@@ -1,7 +1,7 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:go_router/go_router.dart';
-import 'package:mediashin/services/ffmpeg.dart';
-import 'package:mediashin/services/ffprobe.dart';
+import 'package:mediashin/services/ffmpeg_service.dart';
+import 'package:mediashin/services/ffprobe_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -30,8 +30,8 @@ class _HomePageState extends State<HomePage> with WindowListener {
   }
 
   Future<Map<String, bool>> _checkDependencies() async {
-    final ffmpeg = await Ffmpeg().isInstalled();
-    final ffprobe = await Ffprobe().isInstalled();
+    final ffmpeg = await FfmpegService.isInstalled();
+    final ffprobe = await FfprobeService.isInstalled();
     return {
       'ffmpeg': ffmpeg,
       'ffprobe': ffprobe


### PR DESCRIPTION
## Background
Better clarity and ease to access specific functions in the ffmpeg and ffprobe classes.

## Problem
- Both classes' name doesn't explicitly explain what they are.
- isInstalled function needs to be accessed without creating an instance of the class since it is accessed only once in the home page.

## Fix
- Add "Service" into the classes' name.
- Make isInstalled a static function.