### PR TITLE
Feature/add thumbnail of converted video

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,20 +13,18 @@ void main() async {
   runApp(const MediashinApp());
 }
 
-
-void _initWindow() async{
+void _initWindow() async {
   const initSize = Size(960, 540);
   await windowManager.ensureInitialized();
   WindowOptions windowOptions = const WindowOptions(
-    size: initSize,
-    minimumSize: initSize,
-    center: true,
-    backgroundColor: Colors.transparent,
-    skipTaskbar: false,
-    titleBarStyle: TitleBarStyle.hidden,
-    windowButtonVisibility: false,
-    title: 'Mediashin'
-  );
+      size: initSize,
+      minimumSize: initSize,
+      center: true,
+      backgroundColor: Colors.transparent,
+      skipTaskbar: false,
+      titleBarStyle: TitleBarStyle.hidden,
+      windowButtonVisibility: false,
+      title: 'Mediashin');
   windowManager.waitUntilReadyToShow(windowOptions, () async {
     await windowManager.show();
     await windowManager.focus();
@@ -60,103 +58,65 @@ class _MediashinAppState extends State<MediashinApp> {
 }
 
 FluentThemeData _createTheme(Brightness brightness) => FluentThemeData(
-  brightness: brightness,
-  accentColor: AppColors.accentColor.toAccentColor(),
-  visualDensity: VisualDensity.adaptivePlatformDensity,
-  scaffoldBackgroundColor: Colors.transparent,
-  fontFamily: 'NotoSans',
-  acrylicBackgroundColor: const Color(0xFF545454),
-  menuColor: AppColors.primaryColor,
-  dialogTheme: ContentDialogThemeData(
-    titleStyle: const TextStyle(
-      fontVariations: [
-        FontVariation('wght', 600)
-      ],
-      fontSize: 20,
-      height: 28 / 20
+    brightness: brightness,
+    accentColor: AppColors.accentColor.toAccentColor(),
+    visualDensity: VisualDensity.adaptivePlatformDensity,
+    scaffoldBackgroundColor: Colors.transparent,
+    fontFamily: 'NotoSans',
+    acrylicBackgroundColor: const Color(0xFF545454),
+    menuColor: AppColors.primaryColor,
+    dialogTheme: ContentDialogThemeData(
+      titleStyle: const TextStyle(
+          fontVariations: [FontVariation('wght', 600)],
+          fontSize: 20,
+          height: 28 / 20),
+      decoration: BoxDecoration(
+          color: AppColors.primaryColor,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: kElevationToShadow[6]),
+      actionsDecoration: const BoxDecoration(
+          color: AppColors.primaryColorDark,
+          borderRadius: BorderRadius.vertical(bottom: Radius.circular(12))),
     ),
-    decoration: BoxDecoration(
-      color: AppColors.primaryColor,
-      borderRadius: BorderRadius.circular(12),
-      boxShadow: kElevationToShadow[6]
-    ),
-    actionsDecoration: const BoxDecoration(
-      color: AppColors.primaryColorDark,
-      borderRadius: BorderRadius.vertical(bottom: Radius.circular(12))
-    ),
-  ),
-  buttonTheme: const ButtonThemeData(
-    hyperlinkButtonStyle: ButtonStyle(
-      textStyle: WidgetStatePropertyAll(
-        TextStyle(
-          fontVariations: [
-            FontVariation('wght', 400)
-          ],
+    buttonTheme: const ButtonThemeData(
+        hyperlinkButtonStyle: ButtonStyle(
+            textStyle: WidgetStatePropertyAll(TextStyle(
+                fontVariations: [FontVariation('wght', 400)],
+                fontSize: 14,
+                height: 20 / 14)),
+            padding:
+                WidgetStatePropertyAll(EdgeInsets.symmetric(vertical: 8.0)))),
+    typography: const Typography.raw(
+      caption: TextStyle(
+          fontVariations: [FontVariation('wght', 400)],
+          fontSize: 12,
+          height: 16 / 12),
+      body: TextStyle(
+          fontVariations: [FontVariation('wght', 400)],
           fontSize: 14,
-          height: 20 / 14
-        )
-      ),
-      padding: WidgetStatePropertyAll(
-        EdgeInsets.symmetric(vertical: 8.0)
-      )
-    )
-  ),
-  typography: const Typography.raw(
-    caption: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 400)
-      ],
-      fontSize: 12,
-      height: 16 / 12
-    ),
-    body: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 400)
-      ],
-      fontSize: 14,
-      height: 20 / 14
-    ),
-    bodyStrong: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 600)
-      ],
-      fontSize: 14,
-      height: 20 / 14
-    ),
-    bodyLarge: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 400)
-      ],
-      fontSize: 18,
-      height: 24 / 18
-    ),
-    subtitle: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 600)
-      ],
-      fontSize: 20,
-      height: 28 / 20
-    ),
-    title: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 600)
-      ],
-      fontSize: 28,
-      height: 36 / 28
-    ),
-    titleLarge: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 600)
-      ],
-      fontSize: 40,
-      height: 52 / 40
-    ),
-    display: TextStyle(
-      fontVariations: [
-        FontVariation('wght', 600)
-      ],
-      fontSize: 68,
-      height: 92 / 68
-    ),
-  )
-);
+          height: 20 / 14),
+      bodyStrong: TextStyle(
+          fontVariations: [FontVariation('wght', 600)],
+          fontSize: 14,
+          height: 20 / 14),
+      bodyLarge: TextStyle(
+          fontVariations: [FontVariation('wght', 400)],
+          fontSize: 18,
+          height: 24 / 18),
+      subtitle: TextStyle(
+          fontVariations: [FontVariation('wght', 600)],
+          fontSize: 20,
+          height: 28 / 20),
+      title: TextStyle(
+          fontVariations: [FontVariation('wght', 600)],
+          fontSize: 28,
+          height: 36 / 28),
+      titleLarge: TextStyle(
+          fontVariations: [FontVariation('wght', 600)],
+          fontSize: 40,
+          height: 52 / 40),
+      display: TextStyle(
+          fontVariations: [FontVariation('wght', 600)],
+          fontSize: 68,
+          height: 92 / 68),
+    ));

--- a/lib/models/collections/colors.dart
+++ b/lib/models/collections/colors.dart
@@ -23,3 +23,4 @@ class AppColors {
   static const Color onError = Color(0xFFFFFFFF);
   static const Color accentText = Color(0xFF99EBFF);
 }
+

--- a/lib/models/collections/statics.dart
+++ b/lib/models/collections/statics.dart
@@ -28,7 +28,7 @@ final List<String> videoCodec = [
   'hevc',
   'hevc_nvenc',
   'h264_nvenc',
-  'mpeg4'
+  'mpeg4',
   'vp8',
   'vp9',
 ];

--- a/lib/models/collections/statics.dart
+++ b/lib/models/collections/statics.dart
@@ -33,6 +33,11 @@ final List<String> videoCodec = [
   'vp9',
 ];
 
+final List<String> videoFormat = [
+  'mp4',
+  'mkv'
+];
+
 final List<String> audioCodec = [
   'copy',
   'aac',

--- a/lib/models/collections/statics.dart
+++ b/lib/models/collections/statics.dart
@@ -5,19 +5,23 @@ class MediashinFunction {
   final String name;
   final String desc;
 
-  const MediashinFunction(this. id, this.name, this.desc);
+  const MediashinFunction(this.id, this.name, this.desc);
 }
 
 final List<MediashinFunction> pages = [
   const MediashinFunction(0, 'Analyze', 'Get info about the video.'),
   const MediashinFunction(1, 'Convert', 'Convert video into another encoding.'),
-  const MediashinFunction(2, 'Extract', 'Extract audio and video from the video.'),
+  const MediashinFunction(
+      2, 'Extract', 'Extract audio and video from the video.'),
 ];
 
-List<Widget> spacerInColumn(double gap, Iterable<Widget> children) => children.expand((item) sync* {
-    yield SizedBox(height: gap);
-    yield item;
-}).skip(1).toList();
+List<Widget> spacerInColumn(double gap, Iterable<Widget> children) => children
+    .expand((item) sync* {
+      yield SizedBox(height: gap);
+      yield item;
+    })
+    .skip(1)
+    .toList();
 
 final List<String> fileSize = ['KB', 'MB', 'GB', 'TB'];
 
@@ -33,10 +37,7 @@ final List<String> videoCodec = [
   'vp9',
 ];
 
-final List<String> videoFormat = [
-  'mp4',
-  'mkv'
-];
+final List<String> videoFormat = ['mp4', 'mkv'];
 
 final List<String> audioCodec = [
   'copy',

--- a/lib/models/video_details.dart
+++ b/lib/models/video_details.dart
@@ -1,87 +1,96 @@
 import 'dart:convert';
 
 class VideoDetails {
-    final Error? error;
-    final List<dynamic>? programs;
-    final List<Stream>? streams;
-    final Format? format;
+  final Error? error;
+  final List<dynamic>? programs;
+  final List<Stream>? streams;
+  final Format? format;
 
-    VideoDetails({
-        this.error,
-        this.programs,
-        this.streams,
-        this.format,
-    });
+  VideoDetails({
+    this.error,
+    this.programs,
+    this.streams,
+    this.format,
+  });
 
-    factory VideoDetails.fromRawJson(String str) => VideoDetails.fromJson(json.decode(str));
+  factory VideoDetails.fromRawJson(String str) =>
+      VideoDetails.fromJson(json.decode(str));
 
-    String toRawJson() => json.encode(toJson());
+  String toRawJson() => json.encode(toJson());
 
-    factory VideoDetails.fromJson(Map<String, dynamic> json) => VideoDetails(
+  factory VideoDetails.fromJson(Map<String, dynamic> json) => VideoDetails(
         error: json["error"] == null ? null : Error.fromJson(json["error"]),
-        programs: json["programs"] == null ? [] : List<dynamic>.from(json["programs"]!.map((x) => x)),
-        streams: json["streams"] == null ? [] : List<Stream>.from(json["streams"]!.map((x) => Stream.fromJson(x))),
+        programs: json["programs"] == null
+            ? []
+            : List<dynamic>.from(json["programs"]!.map((x) => x)),
+        streams: json["streams"] == null
+            ? []
+            : List<Stream>.from(
+                json["streams"]!.map((x) => Stream.fromJson(x))),
         format: json["format"] == null ? null : Format.fromJson(json["format"]),
-    );
+      );
 
-    Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => {
         "error": error?.toJson(),
-        "programs": programs == null ? [] : List<dynamic>.from(programs!.map((x) => x)),
-        "streams": streams == null ? [] : List<dynamic>.from(streams!.map((x) => x.toJson())),
+        "programs":
+            programs == null ? [] : List<dynamic>.from(programs!.map((x) => x)),
+        "streams": streams == null
+            ? []
+            : List<dynamic>.from(streams!.map((x) => x.toJson())),
         "format": format?.toJson(),
-    };
+      };
 }
 
 class Error {
-    final int? code;
-    final String? string;
+  final int? code;
+  final String? string;
 
-    Error({
-        this.code,
-        this.string,
-    });
+  Error({
+    this.code,
+    this.string,
+  });
 
-    factory Error.fromRawJson(String str) => Error.fromJson(json.decode(str));
+  factory Error.fromRawJson(String str) => Error.fromJson(json.decode(str));
 
-    String toRawJson() => json.encode(toJson());
+  String toRawJson() => json.encode(toJson());
 
-    factory Error.fromJson(Map<String, dynamic> json) => Error(
+  factory Error.fromJson(Map<String, dynamic> json) => Error(
         code: json["code"],
         string: json["string"],
-    );
+      );
 
-    Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => {
         "code": code,
         "string": string,
-    };
+      };
 }
 
 class Format {
-    final String? filename;
-    final int? nbStreams;
-    final String? formatName;
-    final String? formatLongName;
-    final String? duration;
-    final String? size;
-    final String? bitRate;
-    final Tags? tags;
+  final String? filename;
+  final int? nbStreams;
+  final String? formatName;
+  final String? formatLongName;
+  final String? duration;
+  final String? size;
+  final String? bitRate;
+  final Tags? tags;
 
-    Format({
-        this.filename,
-        this.nbStreams,
-        this.formatName,
-        this.formatLongName,
-        this.duration,
-        this.size,
-        this.bitRate,
-        this.tags,
-    });
+  Format({
+    this.filename,
+    this.nbStreams,
+    this.formatName,
+    this.formatLongName,
+    this.duration,
+    this.size,
+    this.bitRate,
+    this.tags,
+  });
 
-    factory Format.fromRawJson(String str) => Format.fromJson(json.decode(str));
+  factory Format.fromRawJson(String str) => Format.fromJson(json.decode(str));
 
-    String toRawJson() => json.encode(toJson());
+  String toRawJson() => json.encode(toJson());
 
-    factory Format.fromJson(Map<String, dynamic> json) => Format(
+  factory Format.fromJson(Map<String, dynamic> json) => Format(
         filename: json["filename"],
         nbStreams: json["nb_streams"],
         formatName: json["format_name"],
@@ -90,9 +99,9 @@ class Format {
         size: json["size"],
         bitRate: json["bit_rate"],
         tags: json["tags"] == null ? null : Tags.fromJson(json["tags"]),
-    );
+      );
 
-    Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => {
         "filename": filename,
         "nb_streams": nbStreams,
         "format_name": formatName,
@@ -101,69 +110,71 @@ class Format {
         "size": size,
         "bit_rate": bitRate,
         "tags": tags?.toJson(),
-    };
+      };
 }
 
 class Tags {
-    final DateTime? creationTime;
+  final DateTime? creationTime;
 
-    Tags({
-        this.creationTime,
-    });
+  Tags({
+    this.creationTime,
+  });
 
-    factory Tags.fromRawJson(String str) => Tags.fromJson(json.decode(str));
+  factory Tags.fromRawJson(String str) => Tags.fromJson(json.decode(str));
 
-    String toRawJson() => json.encode(toJson());
+  String toRawJson() => json.encode(toJson());
 
-    factory Tags.fromJson(Map<String, dynamic> json) => Tags(
-        creationTime: json["creation_time"] == null ? null : DateTime.parse(json["creation_time"]),
-    );
+  factory Tags.fromJson(Map<String, dynamic> json) => Tags(
+        creationTime: json["creation_time"] == null
+            ? null
+            : DateTime.parse(json["creation_time"]),
+      );
 
-    Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => {
         "creation_time": creationTime?.toIso8601String(),
-    };
+      };
 }
 
 class Stream {
-    final int? index;
-    final String? codecName;
-    final String? codecLongName;
-    final String? codecType;
-    final String? codecTagString;
-    final int? width;
-    final int? height;
-    final String? displayAspectRatio;
-    final String? colorRange;
-    final String? rFrameRate;
-    final String? duration;
-    final String? bitRate;
-    final Tags? tags;
-    final String? sampleRate;
-    final int? channels;
+  final int? index;
+  final String? codecName;
+  final String? codecLongName;
+  final String? codecType;
+  final String? codecTagString;
+  final int? width;
+  final int? height;
+  final String? displayAspectRatio;
+  final String? colorRange;
+  final String? rFrameRate;
+  final String? duration;
+  final String? bitRate;
+  final Tags? tags;
+  final String? sampleRate;
+  final int? channels;
 
-    Stream({
-        this.index,
-        this.codecName,
-        this.codecLongName,
-        this.codecType,
-        this.codecTagString,
-        this.width,
-        this.height,
-        this.displayAspectRatio,
-        this.colorRange,
-        this.rFrameRate,
-        this.duration,
-        this.bitRate,
-        this.tags,
-        this.sampleRate,
-        this.channels,
-    });
+  Stream({
+    this.index,
+    this.codecName,
+    this.codecLongName,
+    this.codecType,
+    this.codecTagString,
+    this.width,
+    this.height,
+    this.displayAspectRatio,
+    this.colorRange,
+    this.rFrameRate,
+    this.duration,
+    this.bitRate,
+    this.tags,
+    this.sampleRate,
+    this.channels,
+  });
 
-    factory Stream.fromRawJson(String str) => Stream.fromJson(json.decode(str));
+  factory Stream.fromRawJson(String str) => Stream.fromJson(json.decode(str));
 
-    String toRawJson() => json.encode(toJson());
+  String toRawJson() => json.encode(toJson());
 
-    factory Stream.fromJson(Map<String, dynamic> json) => Stream(
+  factory Stream.fromJson(Map<String, dynamic> json) => Stream(
         index: json["index"],
         codecName: json["codec_name"],
         codecLongName: json["codec_long_name"],
@@ -179,9 +190,9 @@ class Stream {
         tags: json["tags"] == null ? null : Tags.fromJson(json["tags"]),
         sampleRate: json["sample_rate"],
         channels: json["channels"],
-    );
+      );
 
-    Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => {
         "index": index,
         "codec_name": codecName,
         "codec_long_name": codecLongName,
@@ -197,5 +208,5 @@ class Stream {
         "tags": tags?.toJson(),
         "sample_rate": sampleRate,
         "channels": channels,
-    };
+      };
 }

--- a/lib/routes/mediashin_route_page.dart
+++ b/lib/routes/mediashin_route_page.dart
@@ -3,26 +3,22 @@ import 'package:go_router/go_router.dart';
 import 'package:mediashin/models/collections/colors.dart';
 
 class MediashinRoutePage extends CustomTransitionPage {
-  MediashinRoutePage({
-    super.key,
-    required super.child
-  }) : super(
-    transitionsBuilder: (context, animation, secondaryAnimation, child) {
-      return child;
-    }
-  );
+  MediashinRoutePage({super.key, required super.child})
+      : super(transitionsBuilder:
+            (context, animation, secondaryAnimation, child) {
+          return child;
+        });
 
   @override
   Route createRoute(BuildContext context) {
     return FluentPageRoute(
-      builder: (context) => Container(
-        color: AppColors.primaryColor,
-        child: child,
-      ),
-      settings: this,
-      maintainState: maintainState,
-      barrierLabel: barrierLabel,
-      fullscreenDialog: fullscreenDialog
-    );
+        builder: (context) => Container(
+              color: AppColors.primaryColor,
+              child: child,
+            ),
+        settings: this,
+        maintainState: maintainState,
+        barrierLabel: barrierLabel,
+        fullscreenDialog: fullscreenDialog);
   }
 }

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -15,50 +15,37 @@ final router = GoRouter(
     GoRoute(
       path: '/',
       parentNavigatorKey: rootNavigationkey,
-      pageBuilder: (context, state) => MediashinRoutePage(
-        key: state.pageKey,
-        child: const HomePage()
-      ),
+      pageBuilder: (context, state) =>
+          MediashinRoutePage(key: state.pageKey, child: const HomePage()),
     ),
     GoRoute(
       path: '/about',
       parentNavigatorKey: rootNavigationkey,
-      pageBuilder: (context, state) => MediashinRoutePage(
-        key: state.pageKey,
-        child: const AboutPage()
-      ),
+      pageBuilder: (context, state) =>
+          MediashinRoutePage(key: state.pageKey, child: const AboutPage()),
     ),
     GoRoute(
       path: '/licenses',
       parentNavigatorKey: rootNavigationkey,
-      pageBuilder: (context, state) => MediashinRoutePage(
-        key: state.pageKey,
-        child: const LicensePage()
-      ),
+      pageBuilder: (context, state) =>
+          MediashinRoutePage(key: state.pageKey, child: const LicensePage()),
     ),
     GoRoute(
       path: '/analyze',
       parentNavigatorKey: rootNavigationkey,
-      pageBuilder: (context, state) => MediashinRoutePage(
-        key: state.pageKey,
-        child: const AnalyzePage()
-      ),
+      pageBuilder: (context, state) =>
+          MediashinRoutePage(key: state.pageKey, child: const AnalyzePage()),
     ),
     GoRoute(
       path: '/convert',
       parentNavigatorKey: rootNavigationkey,
-      pageBuilder: (context, state) => MediashinRoutePage(
-        key: state.pageKey,
-        child: const ConvertPage()
-      ),
+      pageBuilder: (context, state) =>
+          MediashinRoutePage(key: state.pageKey, child: const ConvertPage()),
     ),
     GoRoute(
-      path: '/extract',
-      parentNavigatorKey: rootNavigationkey,
-      pageBuilder: (context, state) => MediashinRoutePage(
-        key: state.pageKey,
-        child: const ExtractPage()
-      )
-    )
+        path: '/extract',
+        parentNavigatorKey: rootNavigationkey,
+        pageBuilder: (context, state) =>
+            MediashinRoutePage(key: state.pageKey, child: const ExtractPage()))
   ],
 );

--- a/lib/services/ffmpeg_service.dart
+++ b/lib/services/ffmpeg_service.dart
@@ -29,16 +29,30 @@ class FfmpegService {
     String? preset,
     String? sizeLimit,
     String? videoRateValue,
-    String? videoBitrateControl
+    String? videoBitrateControl,
+    required bool addThumbnail
   }) async {
+    List<String> thumbnailArgs = [
+      '-filter_complex "[0:v]thumbnail,trim=end_frame=1,scale=320:-1[thumb]"',
+      '-map "[thumb]"',
+      '-disposition:v:1 attached_pic',
+      '-c:v:1 mjpeg'
+    ];
+
     List<String> args = [
       '-loglevel error',
       '-i "$filePath"',
-      '-c:v $vcodec',
+      '-map_metadata 0',
+      '-map 0',
+      '-c:v:0 $vcodec',
       '-c:a $acodec',
       '-preset $preset',
       '-progress -'
     ];
+
+    if (addThumbnail) {
+      args.insertAll(4, thumbnailArgs);
+    }
 
     if (sizeLimit != null) {
       args.add('-fs $sizeLimit');

--- a/lib/services/ffmpeg_service.dart
+++ b/lib/services/ffmpeg_service.dart
@@ -21,17 +21,16 @@ class FfmpegService {
     return false;
   }
 
-  Future<Process> convert({
-    required String filePath,
-    required String outputFileNameWithPath,
-    String? vcodec,
-    String? acodec,
-    String? preset,
-    String? sizeLimit,
-    String? videoRateValue,
-    String? videoBitrateControl,
-    required bool addThumbnail
-  }) async {
+  Future<Process> convert(
+      {required String filePath,
+      required String outputFileNameWithPath,
+      String? vcodec,
+      String? acodec,
+      String? preset,
+      String? sizeLimit,
+      String? videoRateValue,
+      String? videoBitrateControl,
+      required bool addThumbnail}) async {
     List<String> thumbnailArgs = [
       '-filter_complex "[0:v]thumbnail,trim=end_frame=1,scale=320:-1[thumb]"',
       '-map "[thumb]"',
@@ -60,18 +59,15 @@ class FfmpegService {
 
     if (vcodec != null && vcodec.contains('nvenc')) {
       if (videoBitrateControl != 'crf' && videoRateValue != null) {
-        args.addAll([
-          '-cq:v $videoRateValue',
-          '-rc:v $videoBitrateControl'
-        ]);
+        args.addAll(['-cq:v $videoRateValue', '-rc:v $videoBitrateControl']);
       }
-    }
-    else {
+    } else {
       if (videoBitrateControl == 'crf' && videoRateValue != null) {
         args.add('-crf $videoRateValue');
       }
     }
-    args.add('"$outputFileNameWithPath"'); // outputFilePath must be the last arg
+    args.add(
+        '"$outputFileNameWithPath"'); // outputFilePath must be the last arg
 
     final exe = 'ffmpeg ${args.join(' ')}';
     final res = await Process.start(exe, []);
@@ -79,10 +75,9 @@ class FfmpegService {
     return res;
   }
 
-  Future<Process> extractAudio({
-    required String filePath,
-    required String outputFileNameWithPath
-  }) async {
+  Future<Process> extractAudio(
+      {required String filePath,
+      required String outputFileNameWithPath}) async {
     List<String> args = [
       '-loglevel error',
       '-i "$filePath"',
@@ -90,7 +85,8 @@ class FfmpegService {
       '-progress -'
     ];
 
-    args.add('"$outputFileNameWithPath"'); // outputFilePath must be the last arg
+    args.add(
+        '"$outputFileNameWithPath"'); // outputFilePath must be the last arg
 
     final exe = 'ffmpeg ${args.join(' ')}';
     final res = await Process.start(exe, []);

--- a/lib/services/ffprobe_service.dart
+++ b/lib/services/ffprobe_service.dart
@@ -21,31 +21,26 @@ class FfprobeService {
     return false;
   }
 
-  Future<double> getTotalDuration({
-    required String filePath
-  }) async {
+  Future<double> getTotalDuration({required String filePath}) async {
     final ffprobe = FfprobeService();
     final res = await ffprobe.run(
-      filePath: filePath,
-      printFormat: 'compact',
-      useSexagesimal: false,
-      entries: ['format=duration']
-    );
+        filePath: filePath,
+        printFormat: 'compact',
+        useSexagesimal: false,
+        entries: ['format=duration']);
 
     if (res.isNotEmpty) {
       return double.parse(res.split('=').removeLast());
-    }
-    else {
+    } else {
       return 0.0;
     }
   }
 
-  Future<String> run({
-    required String filePath,
-    required String printFormat,
-    required bool useSexagesimal,
-    required List<String> entries
-  }) async {
+  Future<String> run(
+      {required String filePath,
+      required String printFormat,
+      required bool useSexagesimal,
+      required List<String> entries}) async {
     List<String> args = [
       '-of $printFormat',
       '-i "$filePath"',

--- a/lib/utils/fix_window_stretch_at_launch.dart
+++ b/lib/utils/fix_window_stretch_at_launch.dart
@@ -8,12 +8,8 @@ void fixWindowStretchAtLaunch() {
     WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) async {
       await Future<void>.delayed(const Duration(milliseconds: 100), () {
         windowManager.getSize().then((Size value) {
-          windowManager.setSize(
-            Size(value.width + 1, value.height + 1)
-          );
-          windowManager.setSize(
-            Size(value.width, value.height)
-          );
+          windowManager.setSize(Size(value.width + 1, value.height + 1));
+          windowManager.setSize(Size(value.width, value.height));
         });
       });
     });

--- a/lib/utils/select_video_file.dart
+++ b/lib/utils/select_video_file.dart
@@ -5,11 +5,10 @@ Future<String> selectVideoFile() async {
       type: FileType.video,
       allowMultiple: false,
       withData: false,
-      withReadStream: false
-    );
+      withReadStream: false);
 
-    if (filePickerResult != null) {
-      return filePickerResult.files.first.path!;
-    }
-    return '';
+  if (filePickerResult != null) {
+    return filePickerResult.files.first.path!;
+  }
+  return '';
 }

--- a/lib/views/about/about_page.dart
+++ b/lib/views/about/about_page.dart
@@ -12,9 +12,7 @@ class AboutPage extends StatefulWidget {
 }
 
 class _AboutPageState extends State<AboutPage> {
-  Map<String, String> appInfo = {
-    'version': 'N/A'
-  };
+  Map<String, String> appInfo = {'version': 'N/A'};
 
   @override
   void initState() {
@@ -30,13 +28,7 @@ class _AboutPageState extends State<AboutPage> {
   }
 
   TableRow _buildTableRow(Widget label, Widget value) {
-    return TableRow(
-      children: [
-        label,
-        const Center(child: Text(':')),
-        value
-      ]
-    );
+    return TableRow(children: [label, const Center(child: Text(':')), value]);
   }
 
   @override
@@ -49,10 +41,7 @@ class _AboutPageState extends State<AboutPage> {
           backButton: true,
           title: Text('Mediashin'),
         ),
-        Text(
-          'About',
-          style: FluentTheme.of(context).typography.title
-        ),
+        Text('About', style: FluentTheme.of(context).typography.title),
         spacer,
         Text(
           'Mediashin',
@@ -74,39 +63,37 @@ class _AboutPageState extends State<AboutPage> {
             },
             children: [
               _buildTableRow(
-                const Text('Version'),
-                Text('v${appInfo['version']!}')
-              ),
+                  const Text('Version'), Text('v${appInfo['version']!}')),
               _buildTableRow(
-                const Text('Author'),
-                const Hyperlink(
-                  text: 'alberterc',
-                  url: 'https://github.com/alberterc'
-                )
-              ),
+                  const Text('Author'),
+                  const Hyperlink(
+                      text: 'alberterc', url: 'https://github.com/alberterc')),
               _buildTableRow(
-                const Text('Repository'),
-                const Hyperlink(
-                  text: 'github.com/alberterc/mediashin',
-                  url: 'https://github.com/alberterc/mediashin',
-                )
-              ),
+                  const Text('Repository'),
+                  const Hyperlink(
+                    text: 'github.com/alberterc/mediashin',
+                    url: 'https://github.com/alberterc/mediashin',
+                  )),
               _buildTableRow(
-                const Text('License'),
-                const Hyperlink(
-                  text: 'BSD-4-Clause',
-                  url: 'https://raw.githubusercontent.com/alberterc/mediashin/refs/heads/main/LICENSE',
-                )
-              ),
+                  const Text('License'),
+                  const Hyperlink(
+                    text: 'BSD-4-Clause',
+                    url:
+                        'https://raw.githubusercontent.com/alberterc/mediashin/refs/heads/main/LICENSE',
+                  )),
             ],
           ),
         ),
         const SizedBox(height: 16),
         HyperlinkButton(
           onPressed: () => GoRouter.of(context).push('/licenses'),
-          style: FluentTheme.of(context).buttonTheme.hyperlinkButtonStyle?.copyWith(
-            padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0)),
-          ),
+          style: FluentTheme.of(context)
+              .buttonTheme
+              .hyperlinkButtonStyle
+              ?.copyWith(
+                padding: const WidgetStatePropertyAll(
+                    EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0)),
+              ),
           child: const Text('View Licenses'),
         )
       ],

--- a/lib/views/about/license/license_page.dart
+++ b/lib/views/about/license/license_page.dart
@@ -23,8 +23,11 @@ class _LicensePageState extends State<LicensePage> {
   Future _getPackagesData() async {
     await for (final licenseEntry in LicenseRegistry.licenses) {
       for (final package in licenseEntry.packages) {
-        packageEntries.putIfAbsent(package, () => _PackageEntry(occurrences: []));
-        packageEntries[package]!.occurrences.add(licenseEntry.paragraphs.toList());
+        packageEntries.putIfAbsent(
+            package, () => _PackageEntry(occurrences: []));
+        packageEntries[package]!
+            .occurrences
+            .add(licenseEntry.paragraphs.toList());
       }
     }
     setState(() {});
@@ -42,16 +45,12 @@ class _LicensePageState extends State<LicensePage> {
           backButton: true,
           title: Text('Mediashin'),
         ),
-        Text(
-          'Licenses',
-          style: FluentTheme.of(context).typography.title
-        ),
+        Text('Licenses', style: FluentTheme.of(context).typography.title),
         spacer,
         Expanded(
           child: NavigationPaneTheme(
             data: NavigationPaneThemeData(
-              backgroundColor: FluentTheme.of(context).menuColor
-            ),
+                backgroundColor: FluentTheme.of(context).menuColor),
             child: NavigationView(
               pane: NavigationPane(
                 header: const Padding(
@@ -64,32 +63,37 @@ class _LicensePageState extends State<LicensePage> {
                   selectedIndex = index;
                 }),
                 items: packageNames
-                  .asMap()
-                  .entries
-                  .map<NavigationPaneItem>((entry) {
-                    final packageName = entry.value;
-                    final packageEntry = packageEntries[packageName]!;
-                    return PaneItem(
-                      icon: const Icon(FluentIcons.caret_solid_alt, size: 0, color: Colors.transparent),
-                      title: Text(
-                        packageName,
-                        style: FluentTheme.of(context).typography.bodyStrong),
+                    .asMap()
+                    .entries
+                    .map<NavigationPaneItem>((entry) {
+                  final packageName = entry.value;
+                  final packageEntry = packageEntries[packageName]!;
+                  return PaneItem(
+                      icon: const Icon(FluentIcons.caret_solid_alt,
+                          size: 0, color: Colors.transparent),
+                      title: Text(packageName,
+                          style: FluentTheme.of(context).typography.bodyStrong),
                       body: PaneItemBody(
                         header: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
+                            Text(packageName,
+                                style: FluentTheme.of(context)
+                                    .typography
+                                    .bodyStrong
+                                    ?.copyWith(fontSize: 16)),
                             Text(
-                              packageName,
-                              style: FluentTheme.of(context).typography.bodyStrong?.copyWith(fontSize: 16)),
-                            Text(
-                              '${packageEntry.occurrences.length} license${packageEntry.occurrences.length > 1 ? 's' : ''}',
-                              style: FluentTheme.of(context).typography.body?.copyWith(color: const Color.fromARGB(255, 133, 133, 133))
-                            )
+                                '${packageEntry.occurrences.length} license${packageEntry.occurrences.length > 1 ? 's' : ''}',
+                                style: FluentTheme.of(context)
+                                    .typography
+                                    .body
+                                    ?.copyWith(
+                                        color: const Color.fromARGB(
+                                            255, 133, 133, 133)))
                           ],
                         ),
                         content: _LicenseView(packageEntry: packageEntry),
-                      )
-                    );
+                      ));
                 }).toList(),
               ),
             ),
@@ -113,45 +117,38 @@ class _LicenseView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children:
-        packageEntry.occurrences
-          .expand<Widget>((occurrence) sync* {
-            for (final paragraph in occurrence) {
-              yield Padding(
+    return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: packageEntry.occurrences.expand<Widget>((occurrence) sync* {
+          for (final paragraph in occurrence) {
+            yield Padding(
                 padding: EdgeInsetsDirectional.only(
                   top: 8.0,
                   start: paragraph.indent == LicenseParagraph.centeredIndent
-                    ? 0.0
-                    : 16.0 * paragraph.indent,
+                      ? 0.0
+                      : 16.0 * paragraph.indent,
                 ),
                 child: Text(
                   paragraph.text,
                   style: paragraph.indent == LicenseParagraph.centeredIndent
-                    ? FluentTheme.of(context).typography.bodyStrong
-                    : FluentTheme.of(context).typography.body,
+                      ? FluentTheme.of(context).typography.bodyStrong
+                      : FluentTheme.of(context).typography.body,
                   textAlign: paragraph.indent == LicenseParagraph.centeredIndent
-                    ? TextAlign.center
-                    : TextAlign.start,
-                )
-              );
-            }
+                      ? TextAlign.center
+                      : TextAlign.start,
+                ));
+          }
 
-            if (packageEntry.occurrences.indexOf(occurrence) < packageEntry.occurrences.length - 1) {
-              yield const Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Divider(
-                  style: DividerThemeData(
-                    decoration: BoxDecoration(
-                      color: Colors.white
-                    )
-                  ),
-                ),
-              );
-            }
-          })
-          .toList()
-    );
+          if (packageEntry.occurrences.indexOf(occurrence) <
+              packageEntry.occurrences.length - 1) {
+            yield const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Divider(
+                style: DividerThemeData(
+                    decoration: BoxDecoration(color: Colors.white)),
+              ),
+            );
+          }
+        }).toList());
   }
 }

--- a/lib/views/analyze/analyze_page.dart
+++ b/lib/views/analyze/analyze_page.dart
@@ -49,31 +49,27 @@ class _AnalyzePageState extends State<AnalyzePage> with WindowListener {
           backButton: true,
           title: Text('Mediashin'),
         ),
-        Text(
-          'Analyze',
-          style: FluentTheme.of(context).typography.title
-        ),
+        Text('Analyze', style: FluentTheme.of(context).typography.title),
         spacer,
         Expanded(
           child: SingleChildScrollView(
             child: DropTarget(
-              onDragDone: (details) {
-                if (details.files.length == 1) {
-                  _analyzeVideoFile(details.files.first.path);
-                }
-              },
-              onDragEntered: (_) {
-                setState(() {
-                  _draggingFile = true;
-                });
-              },
-              onDragExited: (_) {
-                setState(() {
-                  _draggingFile = false;
-                });
-              },
-              child: _buildBody(context)
-            ),
+                onDragDone: (details) {
+                  if (details.files.length == 1) {
+                    _analyzeVideoFile(details.files.first.path);
+                  }
+                },
+                onDragEntered: (_) {
+                  setState(() {
+                    _draggingFile = true;
+                  });
+                },
+                onDragExited: (_) {
+                  setState(() {
+                    _draggingFile = false;
+                  });
+                },
+                child: _buildBody(context)),
           ),
         )
       ],
@@ -89,86 +85,90 @@ class _AnalyzePageState extends State<AnalyzePage> with WindowListener {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 32.0),
       child: Container(
-        padding: const EdgeInsets.all(8.0),
-        width: _kSimpleDetailContainerWidth,
-        decoration: BoxDecoration(
-          color: _draggingFile ? Colors.white.withOpacity(0.15) : Colors.white.withOpacity(0.05),
-          borderRadius: BorderRadius.circular(7.0)
-        ),
-        child: _isFilePicked
-          ? Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 4.0, bottom: 12.0),
-                  child: SimpleDetails(),
-                ),
-                divider,
+          padding: const EdgeInsets.all(8.0),
+          width: _kSimpleDetailContainerWidth,
+          decoration: BoxDecoration(
+              color: _draggingFile
+                  ? Colors.white.withOpacity(0.15)
+                  : Colors.white.withOpacity(0.05),
+              borderRadius: BorderRadius.circular(7.0)),
+          child: _isFilePicked
+              ? Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4.0, bottom: 12.0),
+                      child: SimpleDetails(),
+                    ),
+                    divider,
 
-                // Huh... is this feature needed or worth to implement?
-                // Padding(
-                //   padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-                //   child: _hyperlinkButton(
-                //     text: 'More Details',
-                //     onPressed: () {
-                //       showDialog(
-                //         context: context,
-                //         builder: (context) {
-                //           return GestureDetector(
-                //             onTap: () => Navigator.pop(context),
-                //             child: const MoreDetails(),
-                //           );
-                //         },
-                //       );
-                //     },
-                //   ),
-                // ),
+                    // Huh... is this feature needed or worth to implement?
+                    // Padding(
+                    //   padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                    //   child: _hyperlinkButton(
+                    //     text: 'More Details',
+                    //     onPressed: () {
+                    //       showDialog(
+                    //         context: context,
+                    //         builder: (context) {
+                    //           return GestureDetector(
+                    //             onTap: () => Navigator.pop(context),
+                    //             child: const MoreDetails(),
+                    //           );
+                    //         },
+                    //       );
+                    //     },
+                    //   ),
+                    // ),
 
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-                  child: _hyperlinkButton(
-                    text: 'Change Video File',
-                    onPressed: () {
-                      selectVideoFile().then((file) {
-                        if (file != '') {
-                          _analyzeVideoFile(file);
-                        }
-                      });
-                    }
-                  ),
-                ),
-                Text(
-                  'or drop a video file here',
-                  style: FluentTheme.of(context).typography.caption!.copyWith(color: Colors.white.withOpacity(0.5)),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                      child: _hyperlinkButton(
+                          text: 'Change Video File',
+                          onPressed: () {
+                            selectVideoFile().then((file) {
+                              if (file != '') {
+                                _analyzeVideoFile(file);
+                              }
+                            });
+                          }),
+                    ),
+                    Text(
+                      'or drop a video file here',
+                      style: FluentTheme.of(context)
+                          .typography
+                          .caption!
+                          .copyWith(color: Colors.white.withOpacity(0.5)),
+                    )
+                  ],
                 )
-              ],
-            )
-          : Column(
-              children: [
-                const Padding(
-                  padding: EdgeInsets.only(top: 4.0, bottom: 12.0),
-                  child: Text('No video file selected.'),
-                ),
-                divider,
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-                  child: _hyperlinkButton(
-                    text: 'Select a Video File',
-                    onPressed: () {
-                      selectVideoFile().then((file) {
-                        if (file != '') {
-                          _analyzeVideoFile(file);
-                        }
-                      });
-                    }
-                  ),
-                ),
-                Text(
-                  'or drop a video file here',
-                  style: FluentTheme.of(context).typography.caption!.copyWith(color: Colors.white.withOpacity(0.5)),
-                )
-              ],
-            )
-      ),
+              : Column(
+                  children: [
+                    const Padding(
+                      padding: EdgeInsets.only(top: 4.0, bottom: 12.0),
+                      child: Text('No video file selected.'),
+                    ),
+                    divider,
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                      child: _hyperlinkButton(
+                          text: 'Select a Video File',
+                          onPressed: () {
+                            selectVideoFile().then((file) {
+                              if (file != '') {
+                                _analyzeVideoFile(file);
+                              }
+                            });
+                          }),
+                    ),
+                    Text(
+                      'or drop a video file here',
+                      style: FluentTheme.of(context)
+                          .typography
+                          .caption!
+                          .copyWith(color: Colors.white.withOpacity(0.5)),
+                    )
+                  ],
+                )),
     );
   }
 
@@ -177,10 +177,11 @@ class _AnalyzePageState extends State<AnalyzePage> with WindowListener {
       onPressed: onPressed ?? () {},
       child: SizedBox(
         width: _kSimpleDetailContainerWidth - 20,
-        child: Text(
-          text ?? 'Button',
-          style: FluentTheme.of(context).typography.body!.copyWith(color: AppColors.accentText)
-        ),
+        child: Text(text ?? 'Button',
+            style: FluentTheme.of(context)
+                .typography
+                .body!
+                .copyWith(color: AppColors.accentText)),
       ),
     );
   }
@@ -188,63 +189,57 @@ class _AnalyzePageState extends State<AnalyzePage> with WindowListener {
   void _analyzeVideoFile(String filePath) async {
     if (lookupMimeType(filePath)!.startsWith('video/')) {
       showDialog(
-        context: context,
-        barrierDismissible: false,
-        dismissWithEsc: false,
-        builder: (dialogContext) {
-          analyzeDialogContext = dialogContext;
-          return ContentDialog(
-            title: const Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Processing...'),
-                SizedBox(height: 6),
-                SizedBox(
-                  width: 330,
-                  child: ProgressBar()
-                ),
+          context: context,
+          barrierDismissible: false,
+          dismissWithEsc: false,
+          builder: (dialogContext) {
+            analyzeDialogContext = dialogContext;
+            return ContentDialog(
+              title: const Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Processing...'),
+                  SizedBox(height: 6),
+                  SizedBox(width: 330, child: ProgressBar()),
+                ],
+              ),
+              content: Text(
+                'Analyzing "${filePath.split('\\').removeLast()}".',
+              ),
+              actions: [
+                HyperlinkButton(
+                  child: const Padding(
+                    padding: kDefaultButtonPadding,
+                    child: Text('Cancel'),
+                  ),
+                  onPressed: () {
+                    if (analyzeDialogContext != null &&
+                        analyzeDialogContext!.mounted) {
+                      Navigator.pop(analyzeDialogContext!);
+                    }
+                  },
+                )
               ],
-            ),
-            content: Text(
-              'Analyzing "${filePath.split('\\').removeLast()}".',
-            ),
-            actions: [
-              HyperlinkButton(
-                child: const Padding(
-                  padding: kDefaultButtonPadding,
-                  child: Text('Cancel'),
-                ),
-                onPressed: () {
-                  if (analyzeDialogContext != null && analyzeDialogContext!.mounted) {
-                    Navigator.pop(analyzeDialogContext!);
-                  }
-                },
-              )
-            ],
-          );
-        }
-      );
+            );
+          });
 
       final ffprobe = FfprobeService();
       var videoDetailsStr = await ffprobe.run(
-        printFormat: 'json',
-        filePath: filePath,
-        useSexagesimal: true,
-        entries: [
-          // TODO: nb_streams, duration, and bit_rate may not be needed
-          'format=filename,nb_streams,format_name,format_long_name,duration,size,bit_rate',
-          'format_tags=creation_time',
-          'stream=index,codec_name,codec_long_name,codec_type,codec_tag_string,width,height,color_range,display_aspect_ratio,r_frame_rate,bit_rate,sample_rate,channels,duration',
-          'stream_tags=creation_time'
-        ]
-      ).whenComplete(
-        () {
-          if (analyzeDialogContext != null && analyzeDialogContext!.mounted) {
-            Navigator.pop(analyzeDialogContext!);
-          }
+          printFormat: 'json',
+          filePath: filePath,
+          useSexagesimal: true,
+          entries: [
+            // TODO: nb_streams, duration, and bit_rate may not be needed
+            'format=filename,nb_streams,format_name,format_long_name,duration,size,bit_rate',
+            'format_tags=creation_time',
+            'stream=index,codec_name,codec_long_name,codec_type,codec_tag_string,width,height,color_range,display_aspect_ratio,r_frame_rate,bit_rate,sample_rate,channels,duration',
+            'stream_tags=creation_time'
+          ]).whenComplete(() {
+        if (analyzeDialogContext != null && analyzeDialogContext!.mounted) {
+          Navigator.pop(analyzeDialogContext!);
         }
-      );
+      });
       _videoDetails = VideoDetails.fromJson(jsonDecode(videoDetailsStr));
       setState(() {
         _isFilePicked = true;
@@ -256,95 +251,123 @@ class _AnalyzePageState extends State<AnalyzePage> with WindowListener {
 class SimpleDetails extends StatelessWidget {
   SimpleDetails({super.key});
 
-  final TableRow rowSpacer = TableRow(
-    children: List.generate(3, (_) => const SizedBox(height: 8.0))
-  );
+  final TableRow rowSpacer =
+      TableRow(children: List.generate(3, (_) => const SizedBox(height: 8.0)));
 
   @override
   Widget build(BuildContext context) {
-    return Table(
-      columnWidths: const <int, TableColumnWidth>{
-        0: FlexColumnWidth(.32),
-        1: FlexColumnWidth(.03),
-        2: FlexColumnWidth(1)
-      },
-      children: [
-        TableRow(
-          children: [
-            Text('Filename', style: FluentTheme.of(context).typography.bodyStrong, maxLines: 2, overflow: TextOverflow.ellipsis,),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text(_videoDetails.format!.filename!, style: FluentTheme.of(context).typography.body)
-          ]
+    return Table(columnWidths: const <int, TableColumnWidth>{
+      0: FlexColumnWidth(.32),
+      1: FlexColumnWidth(.03),
+      2: FlexColumnWidth(1)
+    }, children: [
+      TableRow(children: [
+        Text(
+          'Filename',
+          style: FluentTheme.of(context).typography.bodyStrong,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Duration', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text(_videoDetails.format!.duration!, style: FluentTheme.of(context).typography.body)
-          ]
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Format', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text(_videoDetails.format!.formatName!, style: FluentTheme.of(context).typography.body)
-          ]
+        Text(_videoDetails.format!.filename!,
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Duration', style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Codec', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text(_videoDetails.streams![0].codecName!, style: FluentTheme.of(context).typography.body)
-          ]
+        Text(_videoDetails.format!.duration!,
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Format', style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Resolution', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text(
-              _videoDetails.streams![0].width != null && _videoDetails.streams![0].height != null ? '${_videoDetails.streams![0].width!}x${_videoDetails.streams![0].height!} px' : 'N/A',
-              style: FluentTheme.of(context).typography.body
-            )
-          ]
+        Text(_videoDetails.format!.formatName!,
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Codec', style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Total Bit Rate', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text('${(int.parse(_videoDetails.format!.bitRate!) / 1000).round()} kb/s', style: FluentTheme.of(context).typography.body)
-          ]
+        Text(_videoDetails.streams![0].codecName!,
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Resolution',
+            style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Size', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text('${(int.parse(_videoDetails.format!.size!) / 1000000).round()} MB', style: FluentTheme.of(context).typography.body)
-          ]
+        Text(
+            _videoDetails.streams![0].width != null &&
+                    _videoDetails.streams![0].height != null
+                ? '${_videoDetails.streams![0].width!}x${_videoDetails.streams![0].height!} px'
+                : 'N/A',
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Total Bit Rate',
+            style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Stream Count', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text(_videoDetails.format!.nbStreams!.toString(), style: FluentTheme.of(context).typography.body)
-          ]
+        Text(
+            '${(int.parse(_videoDetails.format!.bitRate!) / 1000).round()} kb/s',
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Size', style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-        rowSpacer,
-        TableRow(
-          children: [
-            Text('Created Time', style: FluentTheme.of(context).typography.bodyStrong),
-            Text(':', style: FluentTheme.of(context).typography.body,),
-            Text(_videoDetails.format!.tags!.creationTime != null ? _videoDetails.format!.tags!.creationTime!.toString() : 'N/A', style: FluentTheme.of(context).typography.body)
-          ]
+        Text('${(int.parse(_videoDetails.format!.size!) / 1000000).round()} MB',
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Stream Count',
+            style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
         ),
-      ]
-    );
+        Text(_videoDetails.format!.nbStreams!.toString(),
+            style: FluentTheme.of(context).typography.body)
+      ]),
+      rowSpacer,
+      TableRow(children: [
+        Text('Created Time',
+            style: FluentTheme.of(context).typography.bodyStrong),
+        Text(
+          ':',
+          style: FluentTheme.of(context).typography.body,
+        ),
+        Text(
+            _videoDetails.format!.tags!.creationTime != null
+                ? _videoDetails.format!.tags!.creationTime!.toString()
+                : 'N/A',
+            style: FluentTheme.of(context).typography.body)
+      ]),
+    ]);
   }
 }
 

--- a/lib/views/convert/convert_page.dart
+++ b/lib/views/convert/convert_page.dart
@@ -30,9 +30,11 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
 
   bool _doLimitOutputSize = false;
   bool _doChangeVideoRate = false;
+  bool _addThumbnail = false;
   String _fileSizeLimitUnit = 'KB';
   String _fileSizeLimit = '';
   String _videoCodec = 'copy';
+  String _videoFormat = 'mp4';
   String _audioCodec = 'copy';
   String _encodePreset = 'medium';
   String _videoRateValue = '24';
@@ -154,12 +156,32 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
                             _outputFileName = value;
                             _checkCanConvert();
                           },
-                          placeholder: 'file name.mp4',
+                          placeholder: 'file name (without file type)',
                           expands: false,
                           maxLines: 1,
                         ),
                       )
                     ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const Text('Output file format:'),
+                      ComboBox(
+                        value: _videoFormat,
+                        onChanged: (val) {
+                          setState(() {
+                            _videoFormat = val!;
+                          });
+                        },
+                        items: videoFormat.map((val) {
+                          return ComboBoxItem(
+                            value: val,
+                            child: Text(val),
+                          );
+                        }).toList(),
+                      )
+                    ]
                   ),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -227,6 +249,21 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
                       )
                     ],
                   ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const Text('Create thumbnail metadata?'),
+                      ToggleSwitch(
+                        checked: _addThumbnail,
+                        onChanged: (val) {
+                          setState(() {
+                            _addThumbnail = val;
+                          });
+                        },
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 2.0,),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
@@ -356,7 +393,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
     if (lookupMimeType(filePath)!.startsWith('video/')) {
       final dir = filePath.split('\\');
       dir.removeLast();
-      final outputFileNameFinal = '${dir.join('\\')}\\$_outputFileName';
+      final outputFileNameFinal = '${dir.join('\\')}\\$_outputFileName.$_videoFormat';
 
       double convertProgress = 0.0;
       StateSetter progressSetstate = (fn) {};
@@ -388,7 +425,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
               ],
             ),
             content: Text(
-              'Converting "$_inputFileName" to "$_outputFileName".',
+              'Converting "$_inputFileName" to "$_outputFileName.$_videoFormat".',
             ),
             actions: [
               HyperlinkButton(
@@ -421,7 +458,8 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
         preset: _encodePreset,
         sizeLimit: _doLimitOutputSize && _fileSizeLimit != '' ? _fileSizeLimit : null,
         videoRateValue: _doChangeVideoRate && _videoRateValue != '' ? _videoRateValue : null,
-        videoBitrateControl: _doChangeVideoRate ? _videoBitrateControl : null
+        videoBitrateControl: _doChangeVideoRate ? _videoBitrateControl : null,
+        addThumbnail: _addThumbnail
       );
 
       // get convert progress
@@ -469,7 +507,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
                 ],
               ),
               content: Text(
-                'Successfully converted "$_inputFileName" to "$_outputFileName".',
+                'Successfully converted "$_inputFileName" to "$_outputFileName.$_videoFormat".',
               ),
               actions: [
                 HyperlinkButton(
@@ -510,7 +548,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
                 ],
               ),
               content: Text(
-                'Failed to convert "$_inputFileName" to "$_outputFileName".',
+                'Failed to convert "$_inputFileName" to "$_outputFileName.$_videoFormat".',
               ),
               actions: [
                 HyperlinkButton(

--- a/lib/views/convert/convert_page.dart
+++ b/lib/views/convert/convert_page.dart
@@ -65,37 +65,34 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
           backButton: true,
           title: Text('Mediashin'),
         ),
-        Text(
-          'Convert',
-          style: FluentTheme.of(context).typography.title
-        ),
+        Text('Convert', style: FluentTheme.of(context).typography.title),
         spacer,
         Expanded(
-          child: SingleChildScrollView(
-            child: DropTarget(
-              onDragDone: (details) {
-                if (details.files.length == 1) {
-                  setState(() {
-                    _filePath = details.files.first.path;
-                    _inputFileName = details.files.first.path.split('\\').removeLast();
-                    _isFilePicked = true;
-                  });
-                }
-              },
-              onDragEntered: (_) {
+            child: SingleChildScrollView(
+          child: DropTarget(
+            onDragDone: (details) {
+              if (details.files.length == 1) {
                 setState(() {
-                  _draggingFile = true;
+                  _filePath = details.files.first.path;
+                  _inputFileName =
+                      details.files.first.path.split('\\').removeLast();
+                  _isFilePicked = true;
                 });
-              },
-              onDragExited: (_) {
-                setState(() {
-                  _draggingFile = false;
-                });
-              },
-              child: _buildBody(context),
-            ),
-          )
-        )
+              }
+            },
+            onDragEntered: (_) {
+              setState(() {
+                _draggingFile = true;
+              });
+            },
+            onDragExited: (_) {
+              setState(() {
+                _draggingFile = false;
+              });
+            },
+            child: _buildBody(context),
+          ),
+        ))
       ],
     );
   }
@@ -109,270 +106,270 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 32.0),
       child: Container(
-        padding: const EdgeInsets.all(8.0),
-        width: _kSimpleDetailContainerWidth,
-        decoration: BoxDecoration(
-          color: _draggingFile ? Colors.white.withOpacity(0.15) : Colors.white.withOpacity(0.05),
-          borderRadius: BorderRadius.circular(7.0)
-        ),
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0, bottom: 12.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: spacerInColumn(10, [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text('Input file:'),
-                      _isFilePicked
-                      ? SizedBox(
-                          width: 250,
-                          child: Tooltip(
-                            message: _filePath,
-                            style: const TooltipThemeData(
-                              waitDuration: Duration()
+          padding: const EdgeInsets.all(8.0),
+          width: _kSimpleDetailContainerWidth,
+          decoration: BoxDecoration(
+              color: _draggingFile
+                  ? Colors.white.withOpacity(0.15)
+                  : Colors.white.withOpacity(0.05),
+              borderRadius: BorderRadius.circular(7.0)),
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 4.0, bottom: 12.0),
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: spacerInColumn(10, [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text('Input file:'),
+                          _isFilePicked
+                              ? SizedBox(
+                                  width: 250,
+                                  child: Tooltip(
+                                    message: _filePath,
+                                    style: const TooltipThemeData(
+                                        waitDuration: Duration()),
+                                    child: Text(_inputFileName,
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                        textAlign: TextAlign.right),
+                                  ),
+                                )
+                              : Text('No file selected',
+                                  style: TextStyle(color: Colors.red)),
+                        ],
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text('Output file name:'),
+                          SizedBox(
+                            width: 200,
+                            child: TextBox(
+                              onChanged: (value) {
+                                _outputFileName = value;
+                                _checkCanConvert();
+                              },
+                              placeholder: 'file name (without file type)',
+                              expands: false,
+                              maxLines: 1,
                             ),
-                            child: Text(
-                              _inputFileName,
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                              textAlign: TextAlign.right
-                            ),
+                          )
+                        ],
+                      ),
+                      Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text('Output file format:'),
+                            ComboBox(
+                              value: _videoFormat,
+                              onChanged: (val) {
+                                setState(() {
+                                  _videoFormat = val!;
+                                });
+                              },
+                              items: videoFormat.map((val) {
+                                return ComboBoxItem(
+                                  value: val,
+                                  child: Text(val),
+                                );
+                              }).toList(),
+                            )
+                          ]),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text(
+                            'Video codec:',
                           ),
-                        )
-                      : Text('No file selected', style: TextStyle(color: Colors.red)),
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text('Output file name:'),
-                      SizedBox(
-                        width: 200,
-                        child: TextBox(
-                          onChanged: (value) {
-                            _outputFileName = value;
-                            _checkCanConvert();
-                          },
-                          placeholder: 'file name (without file type)',
-                          expands: false,
-                          maxLines: 1,
+                          ComboBox(
+                            value: _videoCodec,
+                            onChanged: (val) {
+                              setState(() {
+                                _videoCodec = val!;
+                              });
+                            },
+                            items: videoCodec.map((val) {
+                              return ComboBoxItem(
+                                value: val,
+                                child: Text(val),
+                              );
+                            }).toList(),
+                          )
+                        ],
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text(
+                            'Audio codec:',
+                          ),
+                          ComboBox(
+                            value: _audioCodec,
+                            onChanged: (val) {
+                              setState(() {
+                                _audioCodec = val!;
+                              });
+                            },
+                            items: audioCodec.map((val) {
+                              return ComboBoxItem(
+                                value: val,
+                                child: Text(val),
+                              );
+                            }).toList(),
+                          )
+                        ],
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text(
+                            'Preset:',
+                          ),
+                          ComboBox(
+                            value: _encodePreset,
+                            onChanged: (val) {
+                              setState(() {
+                                _encodePreset = val!;
+                              });
+                            },
+                            items: ffmpegEncodePreset.map((val) {
+                              return ComboBoxItem(
+                                value: val,
+                                child: Text(val),
+                              );
+                            }).toList(),
+                          )
+                        ],
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text('Create thumbnail metadata?'),
+                          ToggleSwitch(
+                            checked: _addThumbnail,
+                            onChanged: (val) {
+                              setState(() {
+                                _addThumbnail = val;
+                              });
+                            },
+                          ),
+                        ],
+                      ),
+                      const SizedBox(
+                        height: 2.0,
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text('Limit output size?'),
+                          ToggleSwitch(
+                            checked: _doLimitOutputSize,
+                            onChanged: (val) {
+                              setState(() {
+                                _doLimitOutputSize = val;
+                              });
+                            },
+                          ),
+                        ],
+                      ),
+                      _videoLimitOutputSizeContainer(),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text('Change video rate?'),
+                          ToggleSwitch(
+                            checked: _doChangeVideoRate,
+                            onChanged: (val) {
+                              setState(() {
+                                _doChangeVideoRate = val;
+                              });
+                            },
+                          ),
+                        ],
+                      ),
+                      _videoBitrateControlContainer(),
+                    ])),
+              ),
+              divider,
+              _canConvert && _isFilePicked
+                  ? Column(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                          child: _hyperlinkButton(
+                              text: 'Convert',
+                              onPressed: () {
+                                if (_filePath != '' && _outputFileName != '') {
+                                  _convertVideoFile(_filePath);
+                                }
+                              }),
                         ),
-                      )
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text('Output file format:'),
-                      ComboBox(
-                        value: _videoFormat,
-                        onChanged: (val) {
-                          setState(() {
-                            _videoFormat = val!;
-                          });
-                        },
-                        items: videoFormat.map((val) {
-                          return ComboBoxItem(
-                            value: val,
-                            child: Text(val),
-                          );
-                        }).toList(),
-                      )
-                    ]
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text(
-                        'Video codec:',
-                      ),
-                      ComboBox(
-                        value: _videoCodec,
-                        onChanged: (val) {
-                          setState(() {
-                            _videoCodec = val!;
-                          });
-                        },
-                        items: videoCodec.map((val) {
-                          return ComboBoxItem(
-                            value: val,
-                            child: Text(val),
-                          );
-                        }).toList(),
-                      )
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text(
-                        'Audio codec:',
-                      ),
-                      ComboBox(
-                        value: _audioCodec,
-                        onChanged: (val) {
-                          setState(() {
-                            _audioCodec = val!;
-                          });
-                        },
-                        items: audioCodec.map((val) {
-                          return ComboBoxItem(
-                            value: val,
-                            child: Text(val),
-                          );
-                        }).toList(),
-                      )
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text(
-                        'Preset:',
-                      ),
-                      ComboBox(
-                        value: _encodePreset,
-                        onChanged: (val) {
-                          setState(() {
-                            _encodePreset = val!;
-                          });
-                        },
-                        items: ffmpegEncodePreset.map((val) {
-                          return ComboBoxItem(
-                            value: val,
-                            child: Text(val),
-                          );
-                        }).toList(),
-                      )
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text('Create thumbnail metadata?'),
-                      ToggleSwitch(
-                        checked: _addThumbnail,
-                        onChanged: (val) {
-                          setState(() {
-                            _addThumbnail = val;
-                          });
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 2.0,),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text('Limit output size?'),
-                      ToggleSwitch(
-                        checked: _doLimitOutputSize,
-                        onChanged: (val) {
-                          setState(() {
-                            _doLimitOutputSize = val;
-                          });
-                        },
-                      ),
-                    ],
-                  ),
-                  _videoLimitOutputSizeContainer(),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text('Change video rate?'),
-                      ToggleSwitch(
-                        checked: _doChangeVideoRate,
-                        onChanged: (val) {
-                          setState(() {
-                            _doChangeVideoRate = val;
-                          });
-                        },
-                      ),
-                    ],
-                  ),
-                  _videoBitrateControlContainer(),
-                ])
-              ),
-            ),
-            divider,
-            _canConvert && _isFilePicked
-            ? Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-                  child: _hyperlinkButton(
-                    text: 'Convert',
-                    onPressed: () {
-                      if (_filePath != '' && _outputFileName != '') {
-                        _convertVideoFile(_filePath);
-                      }
-                    }
-                  ),
-                ),
-                _hyperlinkButton(
-                  text: 'Change Video File',
-                  onPressed: () {
-                    selectVideoFile().then((file) {
-                      if (file != '') {
-                        setState(() {
-                          _filePath = file;
-                          _inputFileName = file.split('\\').removeLast();
-                          _isFilePicked = true;
-                        });
-                      }
-                      _checkCanConvert();
-                    });
-                  }
-                ),
-              ],
-            )
-            : !_canConvert && _isFilePicked
-            ? Padding(
-              padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-              child: _hyperlinkButton(
-                text: 'Change Video File',
-                onPressed: () {
-                  selectVideoFile().then((file) {
-                    if (file != '') {
-                      setState(() {
-                        _filePath = file;
-                        _inputFileName = file.split('\\').removeLast();
-                        _isFilePicked = true;
-                      });
-                    }
-                    _checkCanConvert();
-                  });
-                }
-              ),
-            )
-            : Padding(
-              padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-              child: _hyperlinkButton(
-                text: 'Select a Video File',
-                onPressed: () {
-                  selectVideoFile().then((file) {
-                    if (file != '') {
-                      setState(() {
-                        _filePath = file;
-                        _inputFileName = file.split('\\').removeLast();
-                        _isFilePicked = true;
-                      });
-                    }
-                    _checkCanConvert();
-                  });
-                }
-              ),
-            ),
-            Text(
-              'or drop a video file here',
-              style: FluentTheme.of(context).typography.caption!.copyWith(color: Colors.white.withOpacity(0.5)),
-            )
-          ],
-        )
-      ),
+                        _hyperlinkButton(
+                            text: 'Change Video File',
+                            onPressed: () {
+                              selectVideoFile().then((file) {
+                                if (file != '') {
+                                  setState(() {
+                                    _filePath = file;
+                                    _inputFileName =
+                                        file.split('\\').removeLast();
+                                    _isFilePicked = true;
+                                  });
+                                }
+                                _checkCanConvert();
+                              });
+                            }),
+                      ],
+                    )
+                  : !_canConvert && _isFilePicked
+                      ? Padding(
+                          padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                          child: _hyperlinkButton(
+                              text: 'Change Video File',
+                              onPressed: () {
+                                selectVideoFile().then((file) {
+                                  if (file != '') {
+                                    setState(() {
+                                      _filePath = file;
+                                      _inputFileName =
+                                          file.split('\\').removeLast();
+                                      _isFilePicked = true;
+                                    });
+                                  }
+                                  _checkCanConvert();
+                                });
+                              }),
+                        )
+                      : Padding(
+                          padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                          child: _hyperlinkButton(
+                              text: 'Select a Video File',
+                              onPressed: () {
+                                selectVideoFile().then((file) {
+                                  if (file != '') {
+                                    setState(() {
+                                      _filePath = file;
+                                      _inputFileName =
+                                          file.split('\\').removeLast();
+                                      _isFilePicked = true;
+                                    });
+                                  }
+                                  _checkCanConvert();
+                                });
+                              }),
+                        ),
+              Text(
+                'or drop a video file here',
+                style: FluentTheme.of(context)
+                    .typography
+                    .caption!
+                    .copyWith(color: Colors.white.withOpacity(0.5)),
+              )
+            ],
+          )),
     );
   }
 
@@ -381,10 +378,11 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
       onPressed: onPressed ?? () {},
       child: SizedBox(
         width: _kSimpleDetailContainerWidth - 20,
-        child: Text(
-          text ?? 'Button',
-          style: FluentTheme.of(context).typography.body!.copyWith(color: AppColors.accentText)
-        ),
+        child: Text(text ?? 'Button',
+            style: FluentTheme.of(context)
+                .typography
+                .body!
+                .copyWith(color: AppColors.accentText)),
       ),
     );
   }
@@ -393,56 +391,54 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
     if (lookupMimeType(filePath)!.startsWith('video/')) {
       final dir = filePath.split('\\');
       dir.removeLast();
-      final outputFileNameFinal = '${dir.join('\\')}\\$_outputFileName.$_videoFormat';
+      final outputFileNameFinal =
+          '${dir.join('\\')}\\$_outputFileName.$_videoFormat';
 
       double convertProgress = 0.0;
       StateSetter progressSetstate = (fn) {};
 
       showDialog(
-        context: context,
-        barrierDismissible: false,
-        dismissWithEsc: false,
-        builder: (dialogContext) {
-          convertingDialogContext = dialogContext;
-          return ContentDialog(
-            title: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text('Processing...'),
-                const SizedBox(height: 6),
-                SizedBox(
-                  width: 330,
-                  child: StatefulBuilder(
-                    builder: (context, setState) {
-                      progressSetstate = setState;
-                      return ProgressBar(
-                        value: convertProgress,
-                      );
-                    },
-                  )
-                ),
+          context: context,
+          barrierDismissible: false,
+          dismissWithEsc: false,
+          builder: (dialogContext) {
+            convertingDialogContext = dialogContext;
+            return ContentDialog(
+              title: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Processing...'),
+                  const SizedBox(height: 6),
+                  SizedBox(
+                      width: 330,
+                      child: StatefulBuilder(
+                        builder: (context, setState) {
+                          progressSetstate = setState;
+                          return ProgressBar(
+                            value: convertProgress,
+                          );
+                        },
+                      )),
+                ],
+              ),
+              content: Text(
+                'Converting "$_inputFileName" to "$_outputFileName.$_videoFormat".',
+              ),
+              actions: [
+                HyperlinkButton(
+                  child: const Padding(
+                      padding: kDefaultButtonPadding, child: Text('Cancel')),
+                  onPressed: () {
+                    if (convertingDialogContext != null &&
+                        convertingDialogContext!.mounted) {
+                      Navigator.pop(convertingDialogContext!);
+                    }
+                  },
+                )
               ],
-            ),
-            content: Text(
-              'Converting "$_inputFileName" to "$_outputFileName.$_videoFormat".',
-            ),
-            actions: [
-              HyperlinkButton(
-                child: const Padding(
-                  padding: kDefaultButtonPadding,
-                  child: Text('Cancel')
-                ),
-                onPressed: () {
-                  if (convertingDialogContext != null && convertingDialogContext!.mounted) {
-                    Navigator.pop(convertingDialogContext!);
-                  }
-                },
-              )
-            ],
-          );
-        }
-      );
+            );
+          });
 
       // get total duration of video stream
       final ffprobe = FfprobeService();
@@ -451,31 +447,33 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
       // run convert
       final ffmpeg = FfmpegService();
       final res = await ffmpeg.convert(
-        filePath: filePath,
-        outputFileNameWithPath: outputFileNameFinal,
-        vcodec: _videoCodec,
-        acodec: _audioCodec,
-        preset: _encodePreset,
-        sizeLimit: _doLimitOutputSize && _fileSizeLimit != '' ? _fileSizeLimit : null,
-        videoRateValue: _doChangeVideoRate && _videoRateValue != '' ? _videoRateValue : null,
-        videoBitrateControl: _doChangeVideoRate ? _videoBitrateControl : null,
-        addThumbnail: _addThumbnail
-      );
+          filePath: filePath,
+          outputFileNameWithPath: outputFileNameFinal,
+          vcodec: _videoCodec,
+          acodec: _audioCodec,
+          preset: _encodePreset,
+          sizeLimit: _doLimitOutputSize && _fileSizeLimit != ''
+              ? _fileSizeLimit
+              : null,
+          videoRateValue: _doChangeVideoRate && _videoRateValue != ''
+              ? _videoRateValue
+              : null,
+          videoBitrateControl: _doChangeVideoRate ? _videoBitrateControl : null,
+          addThumbnail: _addThumbnail);
 
       // get convert progress
-      await res.stdout
-        .transform(utf8.decoder)
-        .forEach(
-          (line) {
-            if (line.contains('out_time_ms')) {
-              try {
-                final currentDuration = double.parse(line.split('\n')[6].split('=').removeLast());
-                progressSetstate(() {
-                  convertProgress = (currentDuration / 1000000 / totalDuration) * 100;
-                });
-              } catch (_) {}
-            }
-          });
+      await res.stdout.transform(utf8.decoder).forEach((line) {
+        if (line.contains('out_time_ms')) {
+          try {
+            final currentDuration =
+                double.parse(line.split('\n')[6].split('=').removeLast());
+            progressSetstate(() {
+              convertProgress =
+                  (currentDuration / 1000000 / totalDuration) * 100;
+            });
+          } catch (_) {}
+        }
+      });
 
       // after convert is done
       if (convertingDialogContext != null && convertingDialogContext!.mounted) {
@@ -483,85 +481,70 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
       }
       if (await res.exitCode == 0) {
         showDialog(
-          context: context.mounted ? context : context,
-          barrierDismissible: false,
-          dismissWithEsc: false,
-          builder: (dialogContext) {
-            return ContentDialog(
-              title: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  const Text('Successful'),
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Colors.green,
-                      shape: BoxShape.circle
-                    ),
-                    padding: const EdgeInsets.all(8.0),
-                    child: const Icon(
-                      FluentIcons.check_mark,
-                      size: 12,
-                    ),
+            context: context.mounted ? context : context,
+            barrierDismissible: false,
+            dismissWithEsc: false,
+            builder: (dialogContext) {
+              return ContentDialog(
+                  title: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      const Text('Successful'),
+                      Container(
+                        decoration: BoxDecoration(
+                            color: Colors.green, shape: BoxShape.circle),
+                        padding: const EdgeInsets.all(8.0),
+                        child: const Icon(
+                          FluentIcons.check_mark,
+                          size: 12,
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-              content: Text(
-                'Successfully converted "$_inputFileName" to "$_outputFileName.$_videoFormat".',
-              ),
-              actions: [
-                HyperlinkButton(
-                  onPressed: () => Navigator.pop(dialogContext),
-                  child: const Padding(
-                    padding: kDefaultButtonPadding,
-                    child: Text('OK')
-                  )
-                )
-              ]
-            );
-          }
-        );
-      }
-      else {
+                  content: Text(
+                    'Successfully converted "$_inputFileName" to "$_outputFileName.$_videoFormat".',
+                  ),
+                  actions: [
+                    HyperlinkButton(
+                        onPressed: () => Navigator.pop(dialogContext),
+                        child: const Padding(
+                            padding: kDefaultButtonPadding, child: Text('OK')))
+                  ]);
+            });
+      } else {
         showDialog(
-          context: context.mounted ? context : context,
-          barrierDismissible: false,
-          dismissWithEsc: false,
-          builder: (dialogContext) {
-            return ContentDialog(
-              title: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  const Text('Failed'),
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Colors.red,
-                      shape: BoxShape.circle
-                    ),
-                    padding: const EdgeInsets.all(8.0),
-                    child: const Icon(
-                      FluentIcons.chrome_close,
-                      size: 12,
-                    ),
+            context: context.mounted ? context : context,
+            barrierDismissible: false,
+            dismissWithEsc: false,
+            builder: (dialogContext) {
+              return ContentDialog(
+                  title: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      const Text('Failed'),
+                      Container(
+                        decoration: BoxDecoration(
+                            color: Colors.red, shape: BoxShape.circle),
+                        padding: const EdgeInsets.all(8.0),
+                        child: const Icon(
+                          FluentIcons.chrome_close,
+                          size: 12,
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-              content: Text(
-                'Failed to convert "$_inputFileName" to "$_outputFileName.$_videoFormat".',
-              ),
-              actions: [
-                HyperlinkButton(
-                  onPressed: () => Navigator.pop(dialogContext),
-                  child: const Padding(
-                    padding: kDefaultButtonPadding,
-                    child: Text('OK')
-                  )
-                )
-              ]
-            );
-          }
-        );
+                  content: Text(
+                    'Failed to convert "$_inputFileName" to "$_outputFileName.$_videoFormat".',
+                  ),
+                  actions: [
+                    HyperlinkButton(
+                        onPressed: () => Navigator.pop(dialogContext),
+                        child: const Padding(
+                            padding: kDefaultButtonPadding, child: Text('OK')))
+                  ]);
+            });
       }
       res.kill();
     }
@@ -572,8 +555,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
       setState(() {
         _canConvert = true;
       });
-    }
-    else {
+    } else {
       setState(() {
         _canConvert = false;
       });
@@ -585,9 +567,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
       return Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          const Text(
-            'File size limit:'
-          ),
+          const Text('File size limit:'),
           SizedBox(
             width: 170,
             child: TextBox(
@@ -596,9 +576,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
               expands: false,
               maxLines: 1,
               keyboardType: TextInputType.number,
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly
-              ],
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
               onChanged: (value) {
                 _fileSizeLimit = value;
               },
@@ -620,8 +598,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
           ),
         ],
       );
-    }
-    else {
+    } else {
       return const SizedBox();
     }
   }
@@ -632,39 +609,37 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
         children: [
           const SizedBox(height: 6),
           _videoCodec.contains('nvenc')
-          ? Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text(
-                  'Video bitrate control:',
-                ),
-                ComboBox(
-                  value: _videoBitrateControl,
-                  onChanged: (val) {
-                    setState(() {
-                      _videoBitrateControl = val!;
-                    });
-                  },
-                  items: ffmpegVideoBitrateControl.map((val) {
-                    return ComboBoxItem(
-                      value: val,
-                      child: Text(val),
-                    );
-                  }).toList(),
+              ? Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text(
+                      'Video bitrate control:',
+                    ),
+                    ComboBox(
+                      value: _videoBitrateControl,
+                      onChanged: (val) {
+                        setState(() {
+                          _videoBitrateControl = val!;
+                        });
+                      },
+                      items: ffmpegVideoBitrateControl.map((val) {
+                        return ComboBoxItem(
+                          value: val,
+                          child: Text(val),
+                        );
+                      }).toList(),
+                    )
+                  ],
                 )
-              ],
-            )
-          : const Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  'Video bitrate control:',
+              : const Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Video bitrate control:',
+                    ),
+                    Text('crf')
+                  ],
                 ),
-                Text(
-                  'crf'
-                )
-              ],
-            ),
           const SizedBox(height: 10),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -679,9 +654,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
                   expands: false,
                   maxLines: 1,
                   keyboardType: TextInputType.number,
-                  inputFormatters: [
-                    FilteringTextInputFormatter.digitsOnly
-                  ],
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   onChanged: (value) {
                     _videoRateValue = value;
                   },
@@ -691,8 +664,7 @@ class _ConvertPageState extends State<ConvertPage> with WindowListener {
           ),
         ],
       );
-    }
-    else {
+    } else {
       return const SizedBox();
     }
   }

--- a/lib/views/extract/extract_page.dart
+++ b/lib/views/extract/extract_page.dart
@@ -407,11 +407,12 @@ class _ExtractPageState extends State<ExtractPage> with WindowListener {
         if (line.contains('out_time_ms')) {
           try {
             final currentDuration =
-              double.parse(line.split('\n')[6].split('=').removeLast());
+                double.parse(line.split('\n')[6].split('=').removeLast());
             progressSetstate(() {
-              convertProgress = (currentDuration / 1000000 / totalDuration) * 100;
+              convertProgress =
+                  (currentDuration / 1000000 / totalDuration) * 100;
             });
-          } catch(_) {}
+          } catch (_) {}
         }
       });
 

--- a/lib/views/home/home_page.dart
+++ b/lib/views/home/home_page.dart
@@ -16,7 +16,6 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> with WindowListener {
-
   @override
   initState() {
     super.initState();
@@ -32,10 +31,7 @@ class _HomePageState extends State<HomePage> with WindowListener {
   Future<Map<String, bool>> _checkDependencies() async {
     final ffmpeg = await FfmpegService.isInstalled();
     final ffprobe = await FfprobeService.isInstalled();
-    return {
-      'ffmpeg': ffmpeg,
-      'ffprobe': ffprobe
-    };
+    return {'ffmpeg': ffmpeg, 'ffprobe': ffprobe};
   }
 
   @override
@@ -47,10 +43,7 @@ class _HomePageState extends State<HomePage> with WindowListener {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             const WindowTitleBar(),
-            Text(
-              'Mediashin',
-              style: FluentTheme.of(context).typography.title
-            ),
+            Text('Mediashin', style: FluentTheme.of(context).typography.title),
             // spacer,
             // SizedBox(
             //   width: 320,
@@ -70,106 +63,108 @@ class _HomePageState extends State<HomePage> with WindowListener {
             // ),
             spacer,
             FutureBuilder(
-              future: _checkDependencies(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const ProgressRing();
-                }
-                else {
-                  final ffmpeg = snapshot.data?['ffmpeg'] ?? false;
-                  final ffprobe = snapshot.data?['ffprobe'] ?? false;
-                  if (ffmpeg && ffprobe) {
-                    return SingleChildScrollView(
-                      child: _buildBody(context),
-                    );
-                  }
-                  else if (!ffmpeg && !ffprobe) {
-                    return Column(
-                      children: [
-                        Text(
-                          'Ffprobe and Ffmpeg are not found/installed.',
-                          style: FluentTheme.of(context).typography.bodyStrong,
-                        ),
-                        const SizedBox(height: 24.0),
-                        Button(
-                          child: const Text('Click here to download from https://ffmpeg.org/download.html'),
-                          onPressed: () => launchUrl(
-                            Uri.parse('https://ffmpeg.org/download.html'),
-                            mode: LaunchMode.externalApplication
+                future: _checkDependencies(),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const ProgressRing();
+                  } else {
+                    final ffmpeg = snapshot.data?['ffmpeg'] ?? false;
+                    final ffprobe = snapshot.data?['ffprobe'] ?? false;
+                    if (ffmpeg && ffprobe) {
+                      return SingleChildScrollView(
+                        child: _buildBody(context),
+                      );
+                    } else if (!ffmpeg && !ffprobe) {
+                      return Column(
+                        children: [
+                          Text(
+                            'Ffprobe and Ffmpeg are not found/installed.',
+                            style:
+                                FluentTheme.of(context).typography.bodyStrong,
                           ),
-                        ),
-                        const SizedBox(width: 8.0),
-                        Text(
-                          'then put them in your system\'s PATH environment and restart Mediashin.',
-                          style: FluentTheme.of(context).typography.body,
-                        ),
-                      ],
-                    );
-                  }
-                  if (!ffprobe) {
-                    return Column(
-                      children: [
-                        Text(
-                          'Ffprobe is not found/installed.',
-                          style: FluentTheme.of(context).typography.bodyStrong,
-                        ),
-                        const SizedBox(height: 24.0),
-                        Button(
-                          child: const Text('Click here to download from https://ffmpeg.org/download.html'),
-                          onPressed: () => launchUrl(
-                            Uri.parse('https://ffmpeg.org/download.html'),
-                            mode: LaunchMode.externalApplication
+                          const SizedBox(height: 24.0),
+                          Button(
+                            child: const Text(
+                                'Click here to download from https://ffmpeg.org/download.html'),
+                            onPressed: () => launchUrl(
+                                Uri.parse('https://ffmpeg.org/download.html'),
+                                mode: LaunchMode.externalApplication),
                           ),
-                        ),
-                        const SizedBox(width: 8.0),
-                        Text(
-                          'then put it in your system\'s PATH environment and restart Mediashin.',
-                          style: FluentTheme.of(context).typography.body,
-                        ),
-                      ],
-                    );
-                  }
-                  else if (!ffmpeg) {
-                    return Column(
-                      children: [
-                        Text(
-                          'Ffmpeg is not found/installed.',
-                          style: FluentTheme.of(context).typography.bodyStrong,
-                        ),
-                        const SizedBox(height: 24.0),
-                        Button(
-                          child: const Text('Click here to download from https://ffmpeg.org/download.html'),
-                          onPressed: () => launchUrl(
-                            Uri.parse('https://ffmpeg.org/download.html'),
-                            mode: LaunchMode.externalApplication
+                          const SizedBox(width: 8.0),
+                          Text(
+                            'then put them in your system\'s PATH environment and restart Mediashin.',
+                            style: FluentTheme.of(context).typography.body,
                           ),
-                        ),
-                        const SizedBox(width: 8.0),
-                        Text(
-                          'then put it in your system\'s PATH environment and restart Mediashin.',
-                          style: FluentTheme.of(context).typography.body,
-                        ),
-                      ],
-                    );
+                        ],
+                      );
+                    }
+                    if (!ffprobe) {
+                      return Column(
+                        children: [
+                          Text(
+                            'Ffprobe is not found/installed.',
+                            style:
+                                FluentTheme.of(context).typography.bodyStrong,
+                          ),
+                          const SizedBox(height: 24.0),
+                          Button(
+                            child: const Text(
+                                'Click here to download from https://ffmpeg.org/download.html'),
+                            onPressed: () => launchUrl(
+                                Uri.parse('https://ffmpeg.org/download.html'),
+                                mode: LaunchMode.externalApplication),
+                          ),
+                          const SizedBox(width: 8.0),
+                          Text(
+                            'then put it in your system\'s PATH environment and restart Mediashin.',
+                            style: FluentTheme.of(context).typography.body,
+                          ),
+                        ],
+                      );
+                    } else if (!ffmpeg) {
+                      return Column(
+                        children: [
+                          Text(
+                            'Ffmpeg is not found/installed.',
+                            style:
+                                FluentTheme.of(context).typography.bodyStrong,
+                          ),
+                          const SizedBox(height: 24.0),
+                          Button(
+                            child: const Text(
+                                'Click here to download from https://ffmpeg.org/download.html'),
+                            onPressed: () => launchUrl(
+                                Uri.parse('https://ffmpeg.org/download.html'),
+                                mode: LaunchMode.externalApplication),
+                          ),
+                          const SizedBox(width: 8.0),
+                          Text(
+                            'then put it in your system\'s PATH environment and restart Mediashin.',
+                            style: FluentTheme.of(context).typography.body,
+                          ),
+                        ],
+                      );
+                    }
+                    return const SizedBox.shrink();
                   }
-                  return const SizedBox.shrink();
-                }
-              }
-            ),
+                }),
           ],
         ),
         Positioned(
-          bottom: 7,
-          right: 7,
-          child: HyperlinkButton(
-            onPressed: () => context.push('/about'),
-            style: FluentTheme.of(context).buttonTheme.hyperlinkButtonStyle?.copyWith(
-              padding: const WidgetStatePropertyAll(EdgeInsets.all(8.0)),
-              textStyle: WidgetStatePropertyAll(FluentTheme.of(context).typography.caption)
-            ),
-            child: const Text('About'),
-          )
-        ),
+            bottom: 7,
+            right: 7,
+            child: HyperlinkButton(
+              onPressed: () => context.push('/about'),
+              style: FluentTheme.of(context)
+                  .buttonTheme
+                  .hyperlinkButtonStyle
+                  ?.copyWith(
+                      padding:
+                          const WidgetStatePropertyAll(EdgeInsets.all(8.0)),
+                      textStyle: WidgetStatePropertyAll(
+                          FluentTheme.of(context).typography.caption)),
+              child: const Text('About'),
+            )),
       ],
     );
   }
@@ -184,11 +179,10 @@ class _HomePageState extends State<HomePage> with WindowListener {
             child: GridView(
               shrinkWrap: true,
               gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 3,
-                crossAxisSpacing: 8,
-                mainAxisSpacing: 8,
-                childAspectRatio: 267 / 100
-              ),
+                  crossAxisCount: 3,
+                  crossAxisSpacing: 8,
+                  mainAxisSpacing: 8,
+                  childAspectRatio: 267 / 100),
               children: pages.map((page) {
                 return _buildCard(page.name, page.desc, context);
               }).toList(),
@@ -201,23 +195,29 @@ class _HomePageState extends State<HomePage> with WindowListener {
 
   Widget _buildCard(String title, String desc, BuildContext context) {
     return Button(
-    style: const ButtonStyle(
-      padding: WidgetStatePropertyAll(EdgeInsets.symmetric(vertical: 16.0, horizontal: 12.0)),
-      shape: WidgetStatePropertyAll(RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(7.0)))),
-    ),
-    child: Align(
-      alignment: Alignment.centerLeft,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(title, style: FluentTheme.of(context).typography.bodyStrong, textAlign: TextAlign.left),
-          const SizedBox(height: 4.0),
-          Text(desc, style: FluentTheme.of(context).typography.body, textAlign: TextAlign.left)
-        ],
+      style: const ButtonStyle(
+        padding: WidgetStatePropertyAll(
+            EdgeInsets.symmetric(vertical: 16.0, horizontal: 12.0)),
+        shape: WidgetStatePropertyAll(RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(7.0)))),
       ),
-    ),
-    onPressed: () => GoRouter.of(context).push('/${title.toLowerCase()}'),
-  );
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title,
+                style: FluentTheme.of(context).typography.bodyStrong,
+                textAlign: TextAlign.left),
+            const SizedBox(height: 4.0),
+            Text(desc,
+                style: FluentTheme.of(context).typography.body,
+                textAlign: TextAlign.left)
+          ],
+        ),
+      ),
+      onPressed: () => GoRouter.of(context).push('/${title.toLowerCase()}'),
+    );
   }
 }

--- a/lib/widgets/hyperlink.dart
+++ b/lib/widgets/hyperlink.dart
@@ -5,23 +5,25 @@ class Hyperlink extends StatelessWidget {
   final String text;
   final String url;
   final WidgetStateProperty<TextStyle>? textStyle;
-  const Hyperlink({super.key, required this.text, required this.url, this.textStyle});
+  const Hyperlink(
+      {super.key, required this.text, required this.url, this.textStyle});
 
   @override
   Widget build(BuildContext context) {
     return HyperlinkButton(
       style: FluentTheme.of(context).buttonTheme.hyperlinkButtonStyle?.copyWith(
-        padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-        backgroundColor: const WidgetStatePropertyAll(Colors.transparent),
-        textStyle: textStyle ?? WidgetStateProperty.resolveWith((states) {
-          if (states.isHovered) {
-            return const TextStyle(decoration: TextDecoration.underline);
-          } else {
-            return const TextStyle(decoration: TextDecoration.none);
-          }
-        })
-      ),
-      onPressed: () => launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication),
+          padding: const WidgetStatePropertyAll(EdgeInsets.zero),
+          backgroundColor: const WidgetStatePropertyAll(Colors.transparent),
+          textStyle: textStyle ??
+              WidgetStateProperty.resolveWith((states) {
+                if (states.isHovered) {
+                  return const TextStyle(decoration: TextDecoration.underline);
+                } else {
+                  return const TextStyle(decoration: TextDecoration.none);
+                }
+              })),
+      onPressed: () =>
+          launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication),
       child: Align(alignment: Alignment.topLeft, child: Text(text)),
     );
   }

--- a/lib/widgets/pane_item_body.dart
+++ b/lib/widgets/pane_item_body.dart
@@ -16,9 +16,7 @@ class PaneItemBody extends StatelessWidget {
           header,
           const SizedBox(height: 24),
           Expanded(
-            child: SingleChildScrollView(
-              child: content
-            ),
+            child: SingleChildScrollView(child: content),
           )
         ],
       ),

--- a/lib/widgets/window_title_bar.dart
+++ b/lib/widgets/window_title_bar.dart
@@ -3,11 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:window_manager/window_manager.dart';
 
 class WindowTitleBar extends StatefulWidget {
-  const WindowTitleBar({
-    super.key,
-    this.backButton = false,
-    this.title
-  });
+  const WindowTitleBar({super.key, this.backButton = false, this.title});
 
   final bool backButton;
   final Widget? title;
@@ -47,28 +43,26 @@ class _WindowTitleBarState extends State<WindowTitleBar> with WindowListener {
       child: Row(
         children: [
           widget.backButton
-            ? BackButtonTwo(
-              onPressed: () => GoRouter.of(context).pop(),
-            )
-            : const SizedBox(),
+              ? BackButtonTwo(
+                  onPressed: () => GoRouter.of(context).pop(),
+                )
+              : const SizedBox(),
           Expanded(
-            child: DragToMoveArea(
-              child: SizedBox(
-                height: double.infinity,
-                child: Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.only(left: 16),
-                      child: DefaultTextStyle(
-                        style: FluentTheme.of(context).typography.caption!,
-                        child: widget.title ?? const SizedBox(),
-                      ),
-                    ),
-                  ],
+              child: DragToMoveArea(
+                  child: SizedBox(
+            height: double.infinity,
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.only(left: 16),
+                  child: DefaultTextStyle(
+                    style: FluentTheme.of(context).typography.caption!,
+                    child: widget.title ?? const SizedBox(),
+                  ),
                 ),
-              )
-            )
-          ),
+              ],
+            ),
+          ))),
           Row(
             children: [
               WindowCaptionButton.minimize(
@@ -110,10 +104,7 @@ class _WindowTitleBarState extends State<WindowTitleBar> with WindowListener {
 }
 
 class BackButtonTwo extends StatelessWidget {
-  const BackButtonTwo({
-    super.key,
-    this.onPressed
-  });
+  const BackButtonTwo({super.key, this.onPressed});
 
   final VoidCallback? onPressed;
 
@@ -122,34 +113,26 @@ class BackButtonTwo extends StatelessWidget {
     var res = FluentTheme.of(context).resources;
     return Center(
       child: Button(
-        onPressed: onPressed,
-        style: ButtonStyle(
-          backgroundColor: WidgetStateProperty.resolveWith((states) {
-            if (states.isPressed) {
-              return const Color(0xffC42B1C).withOpacity(0.9);
-            }
-            else if (states.isHovered) {
-              return const Color(0xffC42B1C);
-            }
-            else if (states.isDisabled) {
-              return res.controlFillColorDisabled;
-            }
-            else {
-              return Colors.transparent;
-            }
-          }),
-          shape: const WidgetStatePropertyAll(RoundedRectangleBorder()),
-          padding: const WidgetStatePropertyAll(EdgeInsets.all(0)),
-        ),
-        child: Container(
-          constraints: const BoxConstraints(minWidth: 46, minHeight: 32),
-          child: const Icon(
-            FluentIcons.back,
-            color: Colors.white,
-            size: 12.0
-          )
-        )
-      ),
+          onPressed: onPressed,
+          style: ButtonStyle(
+            backgroundColor: WidgetStateProperty.resolveWith((states) {
+              if (states.isPressed) {
+                return const Color(0xffC42B1C).withOpacity(0.9);
+              } else if (states.isHovered) {
+                return const Color(0xffC42B1C);
+              } else if (states.isDisabled) {
+                return res.controlFillColorDisabled;
+              } else {
+                return Colors.transparent;
+              }
+            }),
+            shape: const WidgetStatePropertyAll(RoundedRectangleBorder()),
+            padding: const WidgetStatePropertyAll(EdgeInsets.all(0)),
+          ),
+          child: Container(
+              constraints: const BoxConstraints(minWidth: 46, minHeight: 32),
+              child: const Icon(FluentIcons.back,
+                  color: Colors.white, size: 12.0))),
     );
   }
 }


### PR DESCRIPTION
## Background
- A converted video file may not have a thumbnail when viewing from a File Explorer (except H264 encoding because Windows can automatically create the thumbnail).
- A converted video file will not have all audio tracks.
- Most metadata is not present in the converted video file (i.e. creation date)
- MPEG4 and VP8 encoding is broken.
- The need to include the file type when converting a video file which is inconsistent because the extract option doesn't need it.

## Problem
- If the original video file doesn't have a thumbnail metadata, the converted video file only relies on the operating system to automatically create a thumbnail to show in a file explorer.
- Ffmpeg does not automatically map all audio tracks into a converted video file.
- Ffmpeg does not automatically map all metadata into a converted video file.
- 'mpeg4' and 'vp8' is written wrong in the source code.
- There are multiple video file types that are supported in ffmpeg that may need a different command arguments for each of them.

## Fix
- Create an option to create a thumbnail metadata into the converted video file and the corresponding commands for ffmpeg.
- Include the map command for ffmpeg.
- Include the map_metadata command for ffmpeg.
- Fix 'mpeg4' and 'vp8' in the source code (it was missing a comma).
- Currently, only provide support for mp4 and mkv file type.